### PR TITLE
Use separate bitflag contains calls in check_errors

### DIFF
--- a/src/full_speed/endpoint.rs
+++ b/src/full_speed/endpoint.rs
@@ -49,7 +49,10 @@ impl Endpoint {
     /// an error
     pub fn check_errors(&self) -> Result<(), UsbError> {
         let status = self.td.status();
-        if status.contains(Status::TRANSACTION_ERROR | Status::DATA_BUS_ERROR | Status::HALTED) {
+        if status.contains(Status::TRANSACTION_ERROR)
+            | status.contains(Status::DATA_BUS_ERROR)
+            | status.contains(Status::HALTED)
+        {
             Err(UsbError::InvalidState)
         } else {
             Ok(())


### PR DESCRIPTION
[bitflags.contains](https://docs.rs/bitflags/1.2.1/bitflags/example_generated/struct.Flags.html#method.contains) returns `true` if _all_ of the flags are present. I have a dev branch based on c37c671e10c411fddf995098e5172944c6aab906, attempting to add isochronous support, and this caused `TRANSACTION_ERROR` statuses to panic (after using the try_into implementation).

In this implementation, I think this would cause errors to silently be ignored, but I haven't tested it.
