### PR TITLE
Remove requirement for EP0 max packet size

### DIFF
--- a/examples/teensy4/Cargo.toml
+++ b/examples/teensy4/Cargo.toml
@@ -71,7 +71,3 @@ path = "src/support.rs"
 [[bin]]
 name = "test_class"
 path = "src/test_class.rs"
-
-[patch.crates-io.usb-device]
-git = "https://github.com/imxrt-rs/usb-device.git"
-branch = "imxrt-test-class-support"

--- a/examples/teensy4/src/configured.rs
+++ b/examples/teensy4/src/configured.rs
@@ -58,7 +58,6 @@ fn main() -> ! {
     let bus = usb_device::bus::UsbBusAllocator::new(bus_adapter);
     let mut device = UsbDeviceBuilder::new(&bus, UsbVidPid(0x5824, 0x27dd))
         .product("imxrt-usbd")
-        .max_packet_size_0(64)
         .build();
 
     loop {

--- a/examples/teensy4/src/serial.rs
+++ b/examples/teensy4/src/serial.rs
@@ -79,7 +79,6 @@ fn main() -> ! {
     let mut serial = usbd_serial::SerialPort::new(&bus);
     let mut device = UsbDeviceBuilder::new(&bus, UsbVidPid(0x5824, 0x27dd))
         .product("imxrt-usbd")
-        .max_packet_size_0(64)
         .device_class(usbd_serial::USB_CLASS_CDC)
         .build();
 

--- a/examples/teensy4/src/test_class.rs
+++ b/examples/teensy4/src/test_class.rs
@@ -80,7 +80,7 @@ fn main() -> ! {
         CLASS = Some(test_class);
         let test_class = CLASS.as_ref().unwrap();
 
-        let device = test_class.make_device_builder(bus).build();
+        let device = test_class.make_device(bus);
 
         DEVICE = Some(device);
 

--- a/examples/teensy4/src/test_class.rs
+++ b/examples/teensy4/src/test_class.rs
@@ -80,10 +80,7 @@ fn main() -> ! {
         CLASS = Some(test_class);
         let test_class = CLASS.as_ref().unwrap();
 
-        let device = test_class
-            .make_device_builder(bus)
-            .max_packet_size_0(64)
-            .build();
+        let device = test_class.make_device_builder(bus).build();
 
         DEVICE = Some(device);
 

--- a/src/full_speed.rs
+++ b/src/full_speed.rs
@@ -25,32 +25,6 @@
 //! to quickly respond to `poll()` outputs, and schedule the next transfer
 //! in the time required for full-speed devices.
 //!
-//! We do this because that's the behaviors expected by the `usb-device`
-//! implementation. Specifically, `UsbBus::read()` and `write()` are expected
-//! to send *packets*. Furthermore, `UsbBus::poll()` is expected to signal
-//! *packet* completion. Although a TD can describe a transfer of *N* packets,
-//! we cannot know how many packets to associate with each transfer without
-//! implementing our own state machine.
-//!
-//! This detail reveals why we must increase the max packet size for the
-//! control endpoint. Consider a `GET_DESCRIPTOR` device request that expects
-//! 18 bytes, and a control endpoint that supports a max packet size of 8 bytes.
-//! The USB device will call `write()` three times to send 3 packets. To properly
-//! relay the data to the host, we would need to buffer the 18 bytes, then
-//! schedule a single TD to send the 3 packets. However, supporting this would
-//! complicate the driver, and we might be tricking the USB device into thinking
-//! we actually sent the data. Instead, we simplify the driver, and require one packet
-//! per TD. This works until you need to send more than 64 bytes to satsify an EP0
-//! IN data phase, so we're betting that won't happen.
-//!
-//! ## Future work
-//!
-//! This design does not take advangate of the high-speed driver design available
-//! in i.MX RT processors. Although the only difference between high- and full-speed
-//! is the data bandwidth, we've not tested high-speed I/O with this design, and we will
-//! not support it. Therefore, the full-speed driver restricts the potential of the
-//! bus. A future high-speed driver should account for these limitations.
-//!
 //!
 //! [`imxrt-ral`]: https://crates.io/crates/imxrt-ral
 //! [`usb-device`]: https://crates.io/crates/usb-device

--- a/src/full_speed/bus.rs
+++ b/src/full_speed/bus.rs
@@ -19,12 +19,7 @@ use usb_device::{
 /// The driver assumes that you've prepared all USB clocks (CCM clock gates, CCM analog PLLs).
 /// You may use the `imxrt-ral` APIs to configure USB clocks.
 ///
-/// When you build your final `usb-device`, you must set the endpoint 0 max packet
-/// size to 64 bytes. See `UsbDeviceBuilder::max_packet_size_0` for more information.
-/// Failure to increase the control endpoint max packet size will result in a USB device
-/// that cannot communicate with the host.
-///
-/// Additionally, before polling for USB class traffic, you must call [`configure()`](BusAdapter::configure())
+/// Before polling for USB class traffic, you must call [`configure()`](BusAdapter::configure())
 /// *after* your device has been configured. This can be accomplished by polling the USB
 /// device and checking its state until it's been configured. Once configured, use `UsbDevice::bus()`
 /// to access the i.MX RT `BusAdapter`, and call `configure()`. You should only do this once.
@@ -57,7 +52,6 @@ use usb_device::{
 /// let bus_allocator = usb_device::bus::UsbBusAllocator::new(bus_adapter);
 /// let mut device = UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x5824, 0x27dd))
 ///     .product("imxrt-usbd")
-///     .max_packet_size_0(64) // <---- Set the control OUT/IN max packet size to 64
 ///     // Other builder methods...
 ///     .build();
 ///


### PR DESCRIPTION
I was convinced the 64 byte EP0 max packet size was necessary due to differences between how `UsbBus` expected packets to be sent, and how the peripheral schedules multiple packets per transfer. Early prototyping indicated that I couldn't satisfy a data phase without the larger packet size. But after comments in the `usb-device` repo, I tried again, and things seem to work without this large packet size.

This PR removes the EP0 max packet size requirement. Examples continue to work. Whatever previous limitation I was hitting must have been corrected through other refactoring, though I've not gone back to figure out where that happened is.