### PR TITLE
Add support for USB GPTs; test GPTs on Teensy 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ Changelog
 [Unreleased]
 ------------
 
+- Add support for USB general purpose timers (GPT).
 - Fix the endpoint initialization routine, which would incorrectly zero the
   other half's endpoint type.
-- Fix documentation of `full_speed::BusAdapter::new`
+- Fix documentation of `full_speed::BusAdapter::new`.
 
 [0.1.0] 2021-03-11
 ------------------

--- a/examples/teensy4/Cargo.toml
+++ b/examples/teensy4/Cargo.toml
@@ -54,6 +54,10 @@ name = "configured"
 path = "src/configured.rs"
 
 [[bin]]
+name = "gpt"
+path = "src/gpt.rs"
+
+[[bin]]
 name = "serial"
 path = "src/serial.rs"
 

--- a/examples/teensy4/src/gpt.rs
+++ b/examples/teensy4/src/gpt.rs
@@ -1,0 +1,130 @@
+//! Demonstrates a USB GPT.
+//!
+//! This example doesn't perform any USB I/O. It simply toggles an LED on a configurable.
+//! interval.
+
+#![no_std]
+#![no_main]
+
+use hal::ral::interrupt;
+use imxrt_usbd::gpt;
+use support::hal;
+use teensy4_bsp::t40;
+
+//
+// Change these constants to test various
+// GPT settings.
+//
+
+/// How frequently the LED toggles (microseconds).
+const LED_PERIOD_US: u32 = 500_000;
+
+//
+// The GPT settings below should result in an example
+// that appears unchanged. Vary these for quick smoke
+// tests.
+//
+
+/// The GPT instance we're using.
+///
+/// This shouldn't matter.
+const GPT_INSTANCE: gpt::Instance = gpt::Instance::Gpt1;
+/// The GPT mode.
+///
+/// If set to one-shot, the example will implement the behaviors
+/// of repeat mode in software (call `reset()`).
+const GPT_MODE: gpt::Mode = gpt::Mode::Repeat;
+/// Use an interrupt (`true`) or polling (`false`).
+const GPT_INTERRUPT: bool = true;
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    let hal::Peripherals {
+        iomuxc, mut ccm, ..
+    } = hal::Peripherals::take().unwrap();
+    let pins = t40::into_pins(iomuxc);
+    let led = support::configure_led(pins.p13);
+
+    let (ccm, ccm_analog) = ccm.handle.raw();
+    support::ccm::initialize(ccm, ccm_analog);
+
+    let bus_adapter = support::new_bus_adapter();
+    cortex_m::interrupt::free(|cs| {
+        bus_adapter.borrow_gpt(cs, GPT_INSTANCE, |gpt| {
+            gpt.stop();
+            gpt.clear_elapsed();
+            gpt.set_interrupt_enabled(GPT_INTERRUPT);
+            gpt.set_mode(GPT_MODE);
+            gpt.set_load(LED_PERIOD_US);
+            gpt.reset();
+        });
+    });
+
+    if GPT_INTERRUPT {
+        example_interrupt(led, bus_adapter)
+    } else {
+        example_polling(led, bus_adapter)
+    }
+}
+
+/// The endless loop when interrupts are enabled.
+fn example_interrupt(led: teensy4_bsp::LED, bus_adapter: imxrt_usbd::full_speed::BusAdapter) -> ! {
+    static mut BUS_ADAPTER: Option<imxrt_usbd::full_speed::BusAdapter> = None;
+    static mut LED: Option<teensy4_bsp::LED> = None;
+
+    cortex_m::interrupt::free(|cs| unsafe {
+        BUS_ADAPTER = Some(bus_adapter);
+        LED = Some(led);
+        cortex_m::peripheral::NVIC::unmask(interrupt::USB_OTG1);
+        let bus_adapter = BUS_ADAPTER.as_mut().unwrap();
+        bus_adapter.borrow_gpt(cs, GPT_INSTANCE, |gpt| gpt.run());
+    });
+
+    #[cortex_m_rt::interrupt]
+    fn USB_OTG1() {
+        cortex_m::interrupt::free(|cs| {
+            let bus_adapter = unsafe { BUS_ADAPTER.as_mut().unwrap() };
+            let led = unsafe { LED.as_mut().unwrap() };
+
+            bus_adapter.borrow_gpt(cs, GPT_INSTANCE, |gpt| {
+                if gpt.is_elapsed() {
+                    gpt.clear_elapsed();
+                    led.toggle();
+
+                    if GPT_MODE != gpt::Mode::Repeat {
+                        gpt.reset();
+                    }
+                }
+            });
+        });
+    }
+
+    loop {
+        cortex_m::asm::wfi()
+    }
+}
+
+/// The endless loop when interrupts are disabled, and we're polling the
+/// GPT timer for completion.
+fn example_polling(
+    mut led: teensy4_bsp::LED,
+    bus_adapter: imxrt_usbd::full_speed::BusAdapter,
+) -> ! {
+    // Note: running loop in a critical section. A real
+    // system shouldn't do this.
+    cortex_m::interrupt::free(|cs| {
+        bus_adapter.borrow_gpt(cs, GPT_INSTANCE, |gpt| {
+            gpt.run();
+            loop {
+                if gpt.is_elapsed() {
+                    gpt.clear_elapsed();
+                    led.toggle();
+
+                    if GPT_MODE != gpt::Mode::Repeat {
+                        gpt.reset();
+                    }
+                }
+            }
+        })
+    })
+}

--- a/src/full_speed/driver.rs
+++ b/src/full_speed/driver.rs
@@ -7,7 +7,7 @@
 //! notes in the `initialize()` implementation.
 
 use super::{endpoint::Endpoint, state};
-use crate::{buffer, qh, ral, td, QH_COUNT};
+use crate::{buffer, gpt, qh, ral, td, QH_COUNT};
 use usb_device::{
     bus::PollResult,
     endpoint::{EndpointAddress, EndpointType},
@@ -135,6 +135,12 @@ impl FullSpeed {
         } else {
             ral::write_reg!(ral::usb, self.usb, USBINTR, 0);
         }
+    }
+
+    /// Acquire mutable access to a GPT timer
+    pub fn gpt_mut<R>(&mut self, instance: gpt::Instance, f: impl FnOnce(&mut gpt::Gpt) -> R) -> R {
+        let mut gpt = gpt::Gpt::new(&mut self.usb, instance);
+        f(&mut gpt)
     }
 
     pub fn set_address(&mut self, address: u8) {

--- a/src/gpt.rs
+++ b/src/gpt.rs
@@ -1,0 +1,254 @@
+//! USB general purpose timers.
+//!
+//! Each USB OTG peripheral has two general purpose timers (GPT). You can access
+//! GPTs through your USB driver.
+//!
+//! # Example
+//!
+//! This example shows how to access a GPT through the
+//! [`full_speed::BusAdapter`](crate::full_speed::BusAdapter) API. The example skips
+//! the bus adapter and USB device setup in order to focus on the GPT API. See the bus
+//! adapter documentation for more information.
+//!
+//! ```no_run
+//! use imxrt_usbd::full_speed::BusAdapter;
+//! use imxrt_usbd::gpt;
+//!
+//! # struct Ps; use imxrt_usbd::Instance as Inst;
+//! # unsafe impl imxrt_usbd::Peripherals for Ps { fn instance(&self) -> Inst { panic!() } }
+//! # static mut ENDPOINT_MEMORY: [u8; 1024] = [0; 1024];
+//!
+//! # let my_usb_peripherals = // Your Peripherals instance...
+//! #   Ps;
+//! let bus_adapter = BusAdapter::new(
+//!     // ...
+//! #    my_usb_peripherals,
+//! #    unsafe { &mut ENDPOINT_MEMORY }
+//! );
+//!
+//! // Prepare a GPT before creating a USB device
+//! # let cs = unsafe { &cortex_m::interrupt::CriticalSection::new() };
+//! // Note: borrow_cpt requires a critical section. See the docs for
+//! // more information.
+//! bus_adapter.borrow_gpt(cs, gpt::Instance::Gpt0, |gpt| {
+//!     gpt.stop(); // Stop the timer, just in case it's already running...
+//!     gpt.clear_elapsed(); // Clear any outstanding elapsed flags
+//!     gpt.set_interrupt_enabled(false); // Enable or disable interrupts
+//!     gpt.set_load(75_000); // Elapse after 75ms (75000us)
+//!     gpt.set_mode(gpt::Mode::Repeat); // Repeat the timer after it elapses
+//!     gpt.reset(); // Load the value into the counter
+//! });
+//! // The timer isn't running until you call run()...
+//!
+//! # use usb_device::prelude::*;
+//! let bus_allocator = usb_device::bus::UsbBusAllocator::new(bus_adapter);
+//!
+//! let mut device = UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x5824, 0x27dd))
+//!     .product("imxrt-usbd")
+//!     .build();
+//!
+//! // You can still access the timer through the bus() method on
+//! // the USB device.
+//! device.bus().borrow_gpt(cs, gpt::Instance::Gpt0, |gpt| gpt.run()); // Timer running!
+//!
+//! loop {
+//!     device.bus().borrow_gpt(cs, gpt::Instance::Gpt0, |gpt| {
+//!         if gpt.is_elapsed() {
+//!             gpt.clear_elapsed();
+//!             // Timer elapsed!
+//!
+//!             // If your mode is Mode::OneShot, you will need
+//!             // to call reset() to re-enable the timer. You also
+//!             // need to call reset() whenever you change the timer
+//!             // load value.
+//!         }
+//!     });
+//! }
+//! ```
+
+use crate::ral;
+
+/// GPT timer mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum Mode {
+    /// In one shot mode, the timer will count down to zero, generate an interrupt,
+    /// and stop until the counter is reset by software.
+    OneShot = 0,
+    /// In repeat mode, the timer will count down to zero, generate an interrupt and
+    /// automatically reload the counter value to start again.
+    Repeat = 1,
+}
+
+/// GPT instance identifiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum Instance {
+    /// The GPT0 timer instance.
+    Gpt0,
+    /// The GPT1 timer instance.
+    Gpt1,
+}
+
+/// General purpose timer (GPT).
+///
+/// USB GPTs have a 1us resolution. The counter is 24 bits wide. GPTs can generate
+/// USB interrupts that are independent of USB protocol interrupts. This lets you
+/// add additional, time-driven logic into your USB ISR and driver state machine.
+///
+/// See the module-level documentation for an example.
+pub struct Gpt<'a> {
+    /// Borrow of USB registers from a peripheral
+    usb: &'a mut ral::usb::Instance,
+    /// GPT instance
+    gpt: Instance,
+}
+
+impl<'a> Gpt<'a> {
+    /// Create a GPT instance over the USB core registers.
+    ///
+    /// *Why take a mutable reference?* The mutable reference prevents you from
+    /// creating two GPTs that alias the same GPT instance.
+    ///
+    /// *Why not `pub`?* The `ral::usb::Instance` isn't compatible with the
+    /// `imxrt_ral::usb::Instance` type, since we're duplicating the RAL module
+    /// in our package. Since that type isn't exposed outside of this crate, no
+    /// one could create this `Gpt`, anyway.
+    pub(crate) fn new(usb: &'a mut ral::usb::Instance, gpt: Instance) -> Self {
+        Self { usb, gpt }
+    }
+
+    /// Returns the GPT instance identifier.
+    pub fn instance(&self) -> Instance {
+        self.gpt
+    }
+
+    /// Run the GPT timer.
+    ///
+    /// Run will start counting down the timer. Use `stop()` to cancel a running timer.
+    pub fn run(&mut self) {
+        match self.gpt {
+            Instance::Gpt0 => ral::modify_reg!(ral::usb, self.usb, GPTIMER0CTRL, GPTRUN: 1),
+            Instance::Gpt1 => ral::modify_reg!(ral::usb, self.usb, GPTIMER1CTRL, GPTRUN: 1),
+        }
+    }
+
+    /// Indicates if the timer is running (`true`) or stopped (`false`).
+    pub fn is_running(&self) -> bool {
+        match self.gpt {
+            Instance::Gpt0 => ral::read_reg!(ral::usb, self.usb, GPTIMER0CTRL, GPTRUN == 1),
+            Instance::Gpt1 => ral::read_reg!(ral::usb, self.usb, GPTIMER1CTRL, GPTRUN == 1),
+        }
+    }
+
+    /// Stop the timer.
+    pub fn stop(&mut self) {
+        match self.gpt {
+            Instance::Gpt0 => ral::modify_reg!(ral::usb, self.usb, GPTIMER0CTRL, GPTRUN: 0),
+            Instance::Gpt1 => ral::modify_reg!(ral::usb, self.usb, GPTIMER1CTRL, GPTRUN: 0),
+        }
+    }
+
+    /// Reset the timer.
+    ///
+    /// `reset` loads the counter value. It does not stop a running counter.
+    pub fn reset(&mut self) {
+        match self.gpt {
+            Instance::Gpt0 => ral::modify_reg!(ral::usb, self.usb, GPTIMER0CTRL, GPTRST: 1),
+            Instance::Gpt1 => ral::modify_reg!(ral::usb, self.usb, GPTIMER1CTRL, GPTRST: 1),
+        }
+    }
+
+    /// Set the timer mode.
+    pub fn set_mode(&mut self, mode: Mode) {
+        match self.gpt {
+            Instance::Gpt0 => {
+                ral::modify_reg!(ral::usb, self.usb, GPTIMER0CTRL, GPTMODE: mode as u32)
+            }
+            Instance::Gpt1 => {
+                ral::modify_reg!(ral::usb, self.usb, GPTIMER1CTRL, GPTMODE: mode as u32)
+            }
+        }
+    }
+
+    /// Returns the timer mode.
+    pub fn mode(&self) -> Mode {
+        let mode: u32 = match self.gpt {
+            Instance::Gpt0 => {
+                ral::read_reg!(ral::usb, self.usb, GPTIMER0CTRL, GPTMODE)
+            }
+            Instance::Gpt1 => {
+                ral::read_reg!(ral::usb, self.usb, GPTIMER1CTRL, GPTMODE)
+            }
+        };
+
+        if mode == (Mode::Repeat as u32) {
+            Mode::Repeat
+        } else if mode == (Mode::OneShot as u32) {
+            Mode::OneShot
+        } else {
+            // All raw mode values handled
+            unreachable!()
+        }
+    }
+
+    /// Set the counter load value.
+    ///
+    /// `us` is the number of microseconds to count. `us` will saturate at a 24-bit value (0xFFFFFF,
+    /// or 16.777215 seconds). A value of `0` will result in a 1us delay.
+    ///
+    /// Note that the load count value is not loaded until the next call to `reset()` (one shot mode)
+    /// or until after the timer elapses (repeat mode).
+    pub fn set_load(&mut self, us: u32) {
+        let count = us.min(0xFF_FFFF).max(1).saturating_sub(1);
+        match self.gpt {
+            Instance::Gpt0 => ral::write_reg!(ral::usb, self.usb, GPTIMER0LD, count),
+            Instance::Gpt1 => ral::write_reg!(ral::usb, self.usb, GPTIMER1LD, count),
+        }
+    }
+
+    /// Returns the counter load value.
+    pub fn load(&self) -> u32 {
+        match self.gpt {
+            Instance::Gpt0 => ral::read_reg!(ral::usb, self.usb, GPTIMER0LD),
+            Instance::Gpt1 => ral::read_reg!(ral::usb, self.usb, GPTIMER1LD),
+        }
+    }
+
+    /// Indicates if the timer has elapsed.
+    ///
+    /// If the timer has elapsed, you should clear the elapsed flag with `clear_elapsed()`.
+    pub fn is_elapsed(&self) -> bool {
+        match self.gpt {
+            Instance::Gpt0 => ral::read_reg!(ral::usb, self.usb, USBSTS, TI0 == 1),
+            Instance::Gpt1 => ral::read_reg!(ral::usb, self.usb, USBSTS, TI1 == 1),
+        }
+    }
+
+    /// Clear the flag that indicates the timer has elapsed.
+    pub fn clear_elapsed(&mut self) {
+        match self.gpt {
+            Instance::Gpt0 => ral::modify_reg!(ral::usb, self.usb, USBSTS, TI0: 1),
+            Instance::Gpt1 => ral::modify_reg!(ral::usb, self.usb, USBSTS, TI1: 1),
+        }
+    }
+
+    /// Enable or disable interrupt generation when the timer elapses.
+    ///
+    /// If enabled (`true`), an elapsed GPT will generate an interrupt. This happens regardless of the USB
+    /// interrupt enable state.
+    pub fn set_interrupt_enabled(&mut self, enable: bool) {
+        match self.gpt {
+            Instance::Gpt0 => ral::modify_reg!(ral::usb, self.usb, USBINTR, TIE0: enable as u32),
+            Instance::Gpt1 => ral::modify_reg!(ral::usb, self.usb, USBINTR, TIE1: enable as u32),
+        }
+    }
+
+    /// Indicates if interrupt generation is enabled.
+    pub fn is_interrupt_enabled(&self) -> bool {
+        match self.gpt {
+            Instance::Gpt0 => ral::read_reg!(ral::usb, self.usb, USBINTR, TIE0 == 1),
+            Instance::Gpt1 => ral::read_reg!(ral::usb, self.usb, USBINTR, TIE1 == 1),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ mod td;
 mod vcell;
 
 pub mod full_speed;
+pub mod gpt;
 
 /// Eight endpoints, two directions
 const QH_COUNT: usize = 8 * 2;


### PR DESCRIPTION
Each USB peripheral has two dedicated general purpose timers (GPTs).
They're configured through the USB core registers, have a 1us
resolution, and a 24-bit counter. The GPTs can generate interrupts that
are independent of other USB interrupts. This makes GPTs useful for
scheduling USB transfers that are independent of USB traffic or
host-driven events.

This commit adds an API for the GPTs, and access to the GPTs through the
BusAdapter and usb_device APIs. See the documentation for usage.

Tested on the Teensy 4. See the new example that toggles an LED. The
test demonstrates how the GPTs can be used independent of any USB device
I/O.