### PR TITLE
Change GPT interface; fix GPT driver issues

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -245,32 +245,12 @@ impl BusAdapter {
     /// Acquire one of the GPT timer instances.
     ///
     /// `instance` identifies which GPT instance you're accessing.
-    /// `gpt` requires a critical section to guarantee a single
-    /// mutable access to a USB GPT. See `cortex_m::interrupt::free`
-    /// for more information.
+    /// This may take a critical section for the duration of `func`.
     ///
     /// # Panics
     ///
     /// Panics if the GPT instance is already borrowed. This could happen
-    /// if you call `borrow_gpt` again within the `func` callback.
-    pub fn borrow_gpt<R>(
-        &self,
-        cs: &cortex_m::interrupt::CriticalSection,
-        instance: gpt::Instance,
-        func: impl FnOnce(&mut gpt::Gpt) -> R,
-    ) -> R {
-        let usb = self.usb.borrow(cs);
-        usb.borrow_mut().gpt_mut(instance, func)
-    }
-
-    /// Acquire one of the GPT timer instances.
-    ///
-    /// `instance` identifies which GPT instance you're accessing.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the GPT instance is already borrowed. This could happen
-    /// if you call `borrow_gpt` again within the `func` callback.
+    /// if you call `gpt_mut` again within the `func` callback.
     pub fn gpt_mut<R>(&self, instance: gpt::Instance, func: impl FnOnce(&mut gpt::Gpt) -> R) -> R {
         self.with_usb_mut(|usb| usb.gpt_mut(instance, func))
     }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -176,9 +176,9 @@ impl Driver {
     pub fn set_interrupts(&mut self, interrupts: bool) {
         if interrupts {
             // Keep this in sync with the poll() behaviors
-            ral::write_reg!(ral::usb, self.usb, USBINTR, UE: 1, URE: 1, PCE: 1);
+            ral::modify_reg!(ral::usb, self.usb, USBINTR, UE: 1, URE: 1, PCE: 1);
         } else {
-            ral::write_reg!(ral::usb, self.usb, USBINTR, 0);
+            ral::modify_reg!(ral::usb, self.usb, USBINTR, UE: 0, URE: 0, PCE: 0);
         }
     }
 

--- a/src/gpt.rs
+++ b/src/gpt.rs
@@ -26,11 +26,8 @@
 //! #    unsafe { &mut ENDPOINT_MEMORY }
 //! );
 //!
-//! // Prepare a GPT before creating a USB device
-//! # let cs = unsafe { &cortex_m::interrupt::CriticalSection::new() };
-//! // Note: borrow_cpt requires a critical section. See the docs for
-//! // more information.
-//! bus_adapter.borrow_gpt(cs, gpt::Instance::Gpt0, |gpt| {
+//! // Prepare a GPT before creating a USB device;
+//! bus_adapter.gpt_mut(gpt::Instance::Gpt0, |gpt| {
 //!     gpt.stop(); // Stop the timer, just in case it's already running...
 //!     gpt.clear_elapsed(); // Clear any outstanding elapsed flags
 //!     gpt.set_interrupt_enabled(false); // Enable or disable interrupts
@@ -49,10 +46,10 @@
 //!
 //! // You can still access the timer through the bus() method on
 //! // the USB device.
-//! device.bus().borrow_gpt(cs, gpt::Instance::Gpt0, |gpt| gpt.run()); // Timer running!
+//! device.bus().gpt_mut(gpt::Instance::Gpt0, |gpt| gpt.run()); // Timer running!
 //!
 //! loop {
-//!     device.bus().borrow_gpt(cs, gpt::Instance::Gpt0, |gpt| {
+//!     device.bus().gpt_mut(gpt::Instance::Gpt0, |gpt| {
 //!         if gpt.is_elapsed() {
 //!             gpt.clear_elapsed();
 //!             // Timer elapsed!
@@ -228,8 +225,8 @@ impl<'a> Gpt<'a> {
     /// Clear the flag that indicates the timer has elapsed.
     pub fn clear_elapsed(&mut self) {
         match self.gpt {
-            Instance::Gpt0 => ral::modify_reg!(ral::usb, self.usb, USBSTS, TI0: 1),
-            Instance::Gpt1 => ral::modify_reg!(ral::usb, self.usb, USBSTS, TI1: 1),
+            Instance::Gpt0 => ral::write_reg!(ral::usb, self.usb, USBSTS, TI0: 1),
+            Instance::Gpt1 => ral::write_reg!(ral::usb, self.usb, USBSTS, TI1: 1),
         }
     }
 


### PR DESCRIPTION
#17 changed the ways in which we take a critical section. Since the driver takes critical sections, we don't need another critical section just to acquire a GPT handle. This PR changes the GPT accessor interface. Updated docs indicate that the accessor may take a critical section.

It also corrects two incorrect register accesses following #12:

- `clear_elapsed` should write, not modify, the status register. Flags are W1C, and the modify could cause other status bits to be cleared.
- Enabling / disabling driver interrupts should modify, not write, the interrupt flags. A change in interrupt bits from the driver could lower the GPT's interrupt bit, depending on the access order.

GPTs are not released, so these bugs are only on the main branch.