### PR TITLE
Change `Peripherals` trait to return register pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ Changelog
   )
   ```
 
+- **BREAKING** Change the `unsafe trait Peripherals` API. Implementers must now supply the
+  addresses of USB register blocks. See the updated documentation for more details.
+
 - Add support for USB general purpose timers (GPT).
 - Fix the endpoint initialization routine, which would incorrectly zero the
   other half's endpoint type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,17 +22,27 @@ Changelog
 
 - **BREAKING** Users now allocate space for endpoints. For backwards compatibility,
   allocate the maximum amount of endpoints. Supply the endpoint state to your driver's
-  constructor, as show below.
+  constructor, as show by 'new' in the example below.
+
+- **BREAKING** Change the representation of endpoint memory for I/O. Use `EndpointMemory`
+  as a replacement for `static mut [u8; N]`. See the before / after in the example below.
 
   ```rust
+  // NEW: allocate space for endpoint state.
   static EP_STATE: imxrt_usbd::EndpointState = imxrt_usbd::EndpointState::max_endpoints();
+
+  // Endpoint memory before:
+  // static mut EP_MEMORY: [u8; 2048] = [0; 2048];
+  // Endpoint memory after:
+  static EP_MEMORY: imxrt_usbd::EndpointMemory<2048> = imxrt_usbd::EndpointMemory::new();
 
   // ...
 
   imxrt_usbd::BusAdapter::with_speed(
       UsbPeripherals::usb1(),
-      &mut ENDPOINT_MEMORY,
-      &EP_STATE,                  // <-- NEW
+      // unsafe { &mut EP_MEMORY }, // Endpoint memory before
+      &EP_MEMORY,                   // Endpoint memory after
+      &EP_STATE,                    // <-- NEW
       SPEED,
   )
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,23 @@ Changelog
     bus to low / full speed, use `BusAdapter::with_speed`, and provide
     `Speed::LowFull`.
 
+- **BREAKING** Users now allocate space for endpoints. For backwards compatibility,
+  allocate the maximum amount of endpoints. Supply the endpoint state to your driver's
+  constructor, as show below.
+
+  ```rust
+  static EP_STATE: imxrt_usbd::EndpointState = imxrt_usbd::EndpointState::max_endpoints();
+
+  // ...
+
+  imxrt_usbd::BusAdapter::with_speed(
+      UsbPeripherals::usb1(),
+      &mut ENDPOINT_MEMORY,
+      &EP_STATE,                  // <-- NEW
+      SPEED,
+  )
+  ```
+
 - Add support for USB general purpose timers (GPT).
 - Fix the endpoint initialization routine, which would incorrectly zero the
   other half's endpoint type.

--- a/examples/teensy4/src/support.rs
+++ b/examples/teensy4/src/support.rs
@@ -26,11 +26,17 @@ const SPEED: imxrt_usbd::Speed = {
 pub fn new_bus_adapter() -> imxrt_usbd::BusAdapter {
     // If we're here, we have exclusive access to ENDPOINT_MEMORY
     static mut ENDPOINT_MEMORY: [u8; 4096] = [0; 4096];
+    static EP_STATE: imxrt_usbd::EndpointState = imxrt_usbd::EndpointState::max_endpoints();
 
     unsafe {
         // Safety: With proper scoping and checks for singleton access, we ensure the memory is
         // only available to a single caller.
-        imxrt_usbd::BusAdapter::with_speed(UsbPeripherals::usb1(), &mut ENDPOINT_MEMORY, SPEED)
+        imxrt_usbd::BusAdapter::with_speed(
+            UsbPeripherals::usb1(),
+            &mut ENDPOINT_MEMORY,
+            &EP_STATE,
+            SPEED,
+        )
     }
 }
 

--- a/examples/teensy4/src/support.rs
+++ b/examples/teensy4/src/support.rs
@@ -25,19 +25,10 @@ const SPEED: imxrt_usbd::Speed = {
 /// taken.
 pub fn new_bus_adapter() -> imxrt_usbd::BusAdapter {
     // If we're here, we have exclusive access to ENDPOINT_MEMORY
-    static mut ENDPOINT_MEMORY: [u8; 4096] = [0; 4096];
+    static EP_MEMORY: imxrt_usbd::EndpointMemory<4096> = imxrt_usbd::EndpointMemory::new();
     static EP_STATE: imxrt_usbd::EndpointState = imxrt_usbd::EndpointState::max_endpoints();
 
-    unsafe {
-        // Safety: With proper scoping and checks for singleton access, we ensure the memory is
-        // only available to a single caller.
-        imxrt_usbd::BusAdapter::with_speed(
-            UsbPeripherals::usb1(),
-            &mut ENDPOINT_MEMORY,
-            &EP_STATE,
-            SPEED,
-        )
-    }
+    imxrt_usbd::BusAdapter::with_speed(UsbPeripherals::usb1(), &EP_MEMORY, &EP_STATE, SPEED)
 }
 
 #[panic_handler]

--- a/examples/teensy4/src/support.rs
+++ b/examples/teensy4/src/support.rs
@@ -45,8 +45,8 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
 //
 
 struct UsbPeripherals {
-    _usb: ral::usb::Instance,
-    _phy: ral::usbphy::Instance,
+    usb: ral::usb::Instance,
+    phy: ral::usbphy::Instance,
     _nc: ral::usbnc::Instance,
     _analog: ral::usb_analog::Instance,
 }
@@ -55,8 +55,8 @@ impl UsbPeripherals {
     /// Panics if the instances are already taken
     fn usb1() -> UsbPeripherals {
         Self {
-            _usb: ral::usb::USB1::take().unwrap(),
-            _phy: ral::usbphy::USBPHY1::take().unwrap(),
+            usb: ral::usb::USB1::take().unwrap(),
+            phy: ral::usbphy::USBPHY1::take().unwrap(),
             _nc: ral::usbnc::USBNC1::take().unwrap(),
             _analog: ral::usb_analog::USB_ANALOG::take().unwrap(),
         }
@@ -64,8 +64,13 @@ impl UsbPeripherals {
 }
 
 unsafe impl imxrt_usbd::Peripherals for UsbPeripherals {
-    fn instance(&self) -> imxrt_usbd::Instance {
-        imxrt_usbd::Instance::USB1
+    fn usb(&self) -> *const () {
+        let rb: &ral::usb::RegisterBlock = &self.usb;
+        (rb as *const ral::usb::RegisterBlock).cast()
+    }
+    fn usbphy(&self) -> *const () {
+        let rb: &ral::usbphy::RegisterBlock = &self.phy;
+        (rb as *const ral::usbphy::RegisterBlock).cast()
     }
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -17,6 +17,17 @@ unsafe impl Send for crate::buffer::Allocator {}
 impl Allocator {
     /// Create a memory allocator that allocates block from static, mutable memory.
     pub fn new(buffer: &'static mut [u8]) -> Self {
+        // Safety: buffer is static.
+        unsafe { Self::from_buffer(buffer) }
+    }
+
+    /// Create an allocator for a non-static buffer.
+    ///
+    /// # Safety
+    ///
+    /// Caller must make sure that no buffers allocated from this object
+    /// exceed the lifetime of `buffer`.
+    pub(crate) unsafe fn from_buffer(buffer: &mut [u8]) -> Self {
         let start = buffer.as_mut_ptr();
         let ptr = unsafe { start.add(buffer.len()) };
         Allocator { start, ptr }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -46,8 +46,8 @@ pub use super::driver::Speed;
 /// ```no_run
 /// use imxrt_usbd::BusAdapter;
 ///
-/// # struct Ps; use imxrt_usbd::Instance as Inst;
-/// # unsafe impl imxrt_usbd::Peripherals for Ps { fn instance(&self) -> Inst { panic!() } }
+/// # struct Ps;
+/// # unsafe impl imxrt_usbd::Peripherals for Ps { fn usb(&self) -> *const () { panic!() } fn usbphy(&self) -> *const () { panic!() }}
 /// static EP_MEMORY: imxrt_usbd::EndpointMemory<1024> = imxrt_usbd::EndpointMemory::new();
 /// static EP_STATE: imxrt_usbd::EndpointState = imxrt_usbd::EndpointState::max_endpoints();
 ///

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -51,6 +51,16 @@ impl Endpoint {
         buffer: Buffer,
         kind: EndpointType,
     ) -> Self {
+        let max_packet_size = buffer.len();
+        qh.set_zero_length_termination(false);
+        qh.set_max_packet_len(max_packet_size);
+        qh.set_interrupt_on_setup(
+            EndpointType::Control == kind && address.direction() == UsbDirection::Out,
+        );
+
+        td.set_terminate();
+        td.clear_status();
+
         Endpoint {
             address,
             qh,
@@ -58,6 +68,11 @@ impl Endpoint {
             buffer,
             kind,
         }
+    }
+
+    /// Enable ZLT for the given endpoint.
+    pub fn enable_zlt(&mut self) {
+        self.qh.set_zero_length_termination(true);
     }
 
     /// Indicates if the transfer descriptor is active

--- a/src/gpt.rs
+++ b/src/gpt.rs
@@ -17,13 +17,15 @@
 //! # struct Ps; use imxrt_usbd::Instance as Inst;
 //! # unsafe impl imxrt_usbd::Peripherals for Ps { fn instance(&self) -> Inst { panic!() } }
 //! # static mut ENDPOINT_MEMORY: [u8; 1024] = [0; 1024];
+//! # static EP_STATE: imxrt_usbd::EndpointState = imxrt_usbd::EndpointState::max_endpoints();
 //!
 //! # let my_usb_peripherals = // Your Peripherals instance...
 //! #   Ps;
 //! let bus_adapter = BusAdapter::new(
 //!     // ...
 //! #    my_usb_peripherals,
-//! #    unsafe { &mut ENDPOINT_MEMORY }
+//! #    unsafe { &mut ENDPOINT_MEMORY },
+//! #    &EP_STATE,
 //! );
 //!
 //! // Prepare a GPT before creating a USB device;

--- a/src/gpt.rs
+++ b/src/gpt.rs
@@ -16,7 +16,7 @@
 //!
 //! # struct Ps; use imxrt_usbd::Instance as Inst;
 //! # unsafe impl imxrt_usbd::Peripherals for Ps { fn instance(&self) -> Inst { panic!() } }
-//! # static mut ENDPOINT_MEMORY: [u8; 1024] = [0; 1024];
+//! # static EP_MEMORY: imxrt_usbd::EndpointMemory<1024> = imxrt_usbd::EndpointMemory::new();
 //! # static EP_STATE: imxrt_usbd::EndpointState = imxrt_usbd::EndpointState::max_endpoints();
 //!
 //! # let my_usb_peripherals = // Your Peripherals instance...
@@ -24,7 +24,7 @@
 //! let bus_adapter = BusAdapter::new(
 //!     // ...
 //! #    my_usb_peripherals,
-//! #    unsafe { &mut ENDPOINT_MEMORY },
+//! #    &EP_MEMORY,
 //! #    &EP_STATE,
 //! );
 //!

--- a/src/gpt.rs
+++ b/src/gpt.rs
@@ -14,8 +14,8 @@
 //! use imxrt_usbd::BusAdapter;
 //! use imxrt_usbd::gpt;
 //!
-//! # struct Ps; use imxrt_usbd::Instance as Inst;
-//! # unsafe impl imxrt_usbd::Peripherals for Ps { fn instance(&self) -> Inst { panic!() } }
+//! # struct Ps;
+//! # unsafe impl imxrt_usbd::Peripherals for Ps { fn usb(&self) -> *const () { panic!() } fn usbphy(&self) -> *const () { panic!() } }
 //! # static EP_MEMORY: imxrt_usbd::EndpointMemory<1024> = imxrt_usbd::EndpointMemory::new();
 //! # static EP_STATE: imxrt_usbd::EndpointState = imxrt_usbd::EndpointState::max_endpoints();
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ mod state;
 mod td;
 mod vcell;
 
+pub use buffer::EndpointMemory;
 pub use bus::{BusAdapter, Speed};
 pub mod gpt;
 pub use state::{EndpointState, MAX_ENDPOINTS};
@@ -116,7 +117,7 @@ pub use state::{EndpointState, MAX_ENDPOINTS};
 /// let bus = imxrt_usbd::BusAdapter::new(
 ///     peripherals,
 ///     // Rest of setup...
-///     # unsafe { static mut M: [u8; 1] = [0; 1]; &mut M },
+///     # { static EP_MEMORY: imxrt_usbd::EndpointMemory<1> = imxrt_usbd::EndpointMemory::new(); &EP_MEMORY },
 ///     # { static EP_STATE: imxrt_usbd::EndpointState = imxrt_usbd::EndpointState::max_endpoints(); &EP_STATE }
 /// );
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,7 @@ mod vcell;
 
 pub use bus::{BusAdapter, Speed};
 pub mod gpt;
-
-/// Eight endpoints, two directions
-const QH_COUNT: usize = 8 * 2;
+pub use state::{EndpointState, MAX_ENDPOINTS};
 
 /// A type that owns all USB register blocks
 ///
@@ -118,7 +116,8 @@ const QH_COUNT: usize = 8 * 2;
 /// let bus = imxrt_usbd::BusAdapter::new(
 ///     peripherals,
 ///     // Rest of setup...
-///     # unsafe { static mut M: [u8; 1] = [0; 1]; &mut M }
+///     # unsafe { static mut M: [u8; 1] = [0; 1]; &mut M },
+///     # { static EP_STATE: imxrt_usbd::EndpointState = imxrt_usbd::EndpointState::max_endpoints(); &EP_STATE }
 /// );
 /// ```
 pub unsafe trait Peripherals {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,6 @@ pub use state::{EndpointState, MAX_ENDPOINTS};
 ///
 /// - USB core registers
 /// - USB PHY registers
-/// - USB non-core registers
-/// - USB analog registers
 ///
 /// When an instance of `Peripherals` exists, you must make sure that
 /// nothing else, other than the owner of the `Peripherals` object,
@@ -58,10 +56,9 @@ pub use state::{EndpointState, MAX_ENDPOINTS};
 /// operation. Incorrect usage, or failure to ensure exclusive
 /// ownership, could lead to data races and incorrect USB functionality.
 ///
-/// By implementing this trait, you ensure that the [`Instance`]
-/// identifier is valid for your chip. Not all i.MX RT peripherals
-/// have a USB2 peripheral instance, so you must ensure that the
-/// implementation is correct for your chip.
+/// All pointers are expected to point at the starting register block
+/// for the specified peripheral. Calls to the functions must return the
+/// the same value every time they're called.
 ///
 /// # Example
 ///
@@ -75,18 +72,19 @@ pub use state::{EndpointState, MAX_ENDPOINTS};
 ///
 /// ```no_run
 /// # mod ral {
-/// #   use core::ops::Deref; pub struct Instance; impl Deref for Instance { type Target = u32; fn deref(&self) -> &u32 { unsafe { &*(0x402e0200 as *const u32)} } }
+/// #   pub struct RegisterBlock;
+/// #   use core::ops::Deref; pub struct Instance; impl Deref for Instance { type Target = RegisterBlock; fn deref(&self) -> &RegisterBlock { unsafe { &*(0x402e0200 as *const RegisterBlock)} } }
 /// #   pub fn take() -> Result<Instance, ()> { Ok(Instance) }
-/// #   pub mod usb { pub use super::Instance; pub mod USB1 { pub use super::super::take; } }
-/// #   pub mod usbphy { pub use super::Instance; pub mod USBPHY1 { pub use super::super::take; } }
+/// #   pub mod usb { pub use super::{Instance, RegisterBlock}; pub mod USB1 { pub use super::super::take; } }
+/// #   pub mod usbphy { pub use super::{Instance, RegisterBlock}; pub mod USBPHY1 { pub use super::super::take; } }
 /// #   pub mod usbnc { pub use super::Instance; pub mod USBNC1 { pub use super::super::take; } }
 /// #   pub mod usb_analog { pub use super::Instance; pub mod USB_ANALOG { pub use super::super::take; } }
 /// # }
 /// use ral::usb;
 ///
 /// struct Peripherals {
-///     _usb: ral::usb::Instance,
-///     _phy: ral::usbphy::Instance,
+///     usb: ral::usb::Instance,
+///     phy: ral::usbphy::Instance,
 ///     _nc: ral::usbnc::Instance,
 ///     _analog: ral::usb_analog::Instance,
 /// }
@@ -95,8 +93,8 @@ pub use state::{EndpointState, MAX_ENDPOINTS};
 ///     /// Panics if the instances are already taken
 ///     fn usb1() -> Peripherals {
 ///         Self {
-///             _usb: ral::usb::USB1::take().unwrap(),
-///             _phy: ral::usbphy::USBPHY1::take().unwrap(),
+///             usb: ral::usb::USB1::take().unwrap(),
+///             phy: ral::usbphy::USBPHY1::take().unwrap(),
 ///             _nc: ral::usbnc::USBNC1::take().unwrap(),
 ///             _analog: ral::usb_analog::USB_ANALOG::take().unwrap(),
 ///         }
@@ -108,8 +106,13 @@ pub use state::{EndpointState, MAX_ENDPOINTS};
 /// // guaranteed to be singletons. Given this approach, no one else
 /// // can safely access the USB registers.
 /// unsafe impl imxrt_usbd::Peripherals for Peripherals {
-///     fn instance(&self) -> imxrt_usbd::Instance {
-///         imxrt_usbd::Instance::USB1
+///     fn usb(&self) -> *const () {
+///         let rb: &ral::usb::RegisterBlock = &self.usb;
+///         (rb as *const ral::usb::RegisterBlock).cast()
+///     }
+///     fn usbphy(&self) -> *const () {
+///         let rb: &ral::usbphy::RegisterBlock = &self.phy;
+///         (rb as *const ral::usbphy::RegisterBlock).cast()
 ///     }
 /// }
 ///
@@ -122,26 +125,8 @@ pub use state::{EndpointState, MAX_ENDPOINTS};
 /// );
 /// ```
 pub unsafe trait Peripherals {
-    /// Returns the instance identifier for the core registers
-    ///
-    /// **Warning**: some i.MX RT peripherals have only one USB peripheral,
-    /// USB1. The behavior is undefined if you return `Instance::USB2` on
-    /// one of these systems.
-    fn instance(&self) -> Instance;
-}
-
-/// USB instance identifiers
-///
-/// These are *not* USB standards or speeds. They indicate if this
-/// is the USB1 register instance, or the USB2 register instance.
-///
-/// Note that some i.MX RT processors only have one USB instance (USB1).
-/// On those systems, it is invalid to ever indicate the USB2 instance.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(clippy::upper_case_acronyms)] // USB naming makes sense here
-pub enum Instance {
-    /// The first USB register instance
-    USB1,
-    /// The second USB register instance
-    USB2,
+    /// Returns the pointer to the USB register block.
+    fn usb(&self) -> *const ();
+    /// Returns the pointer to the USBPHY register block.
+    fn usbphy(&self) -> *const ();
 }

--- a/src/ral.rs
+++ b/src/ral.rs
@@ -5,7 +5,7 @@ pub mod usbphy;
 
 pub use imxrt_ral::{modify_reg, read_reg, write_reg, RORegister, RWRegister};
 
-use crate::{Instance, Peripherals};
+use crate::Peripherals;
 
 /// The RAL API requires us to treat all endpoint control registers as unique.
 /// We can make it a little easier with this function, the `EndptCtrl` type,
@@ -48,16 +48,10 @@ pub struct Instances {
 /// Converts the core registers into a USB register block instance
 pub fn instances<P: Peripherals>(peripherals: P) -> Instances {
     let usb = usb::Instance {
-        addr: match peripherals.instance() {
-            Instance::USB1 => usb::USB1,
-            Instance::USB2 => usb::USB2,
-        },
+        addr: peripherals.usb().cast(),
     };
     let usbphy = usbphy::Instance {
-        addr: match peripherals.instance() {
-            Instance::USB1 => usbphy::USBPHY1,
-            Instance::USB2 => usbphy::USBPHY2,
-        },
+        addr: peripherals.usbphy().cast(),
     };
     Instances { usb, usbphy }
 }

--- a/src/ral/usb.rs
+++ b/src/ral/usb.rs
@@ -3378,6 +3378,3 @@ impl ::core::ops::Deref for Instance {
 }
 
 unsafe impl Send for Instance {}
-
-pub const USB1: *const RegisterBlock = 0x402e0000 as *const _;
-pub const USB2: *const RegisterBlock = 0x402e0200 as *const _;

--- a/src/ral/usbphy.rs
+++ b/src/ral/usbphy.rs
@@ -1691,6 +1691,3 @@ impl ::core::ops::Deref for Instance {
 }
 
 unsafe impl Send for Instance {}
-
-pub const USBPHY1: *const RegisterBlock = 0x400d9000 as *const _;
-pub const USBPHY2: *const RegisterBlock = 0x400da000 as *const _;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,123 +1,303 @@
-//! Static state that's 'owned' by a driver
-//!
-//! This module allocates the static memory or the USB drivers,
-//! and provides guidance on how to safely access this memory.
+#![allow(clippy::declare_interior_mutable_const)] // Usage is legit in this module.
 
-use crate::QH_COUNT;
-use crate::{qh, ral, td};
+use core::{
+    cell::UnsafeCell,
+    mem::MaybeUninit,
+    sync::atomic::{AtomicU32, Ordering},
+};
+
+use crate::{buffer::Buffer, endpoint::Endpoint, qh::Qh, td::Td};
+use usb_device::{
+    endpoint::{EndpointAddress, EndpointType},
+    UsbDirection,
+};
 
 /// A list of transfer descriptors
 ///
 /// Supports 1 TD per QH (per endpoint direction)
 #[repr(align(32))]
-struct TdList([td::Td; QH_COUNT]);
-const TD_LIST_INIT: TdList = TdList([
-    td::Td::new(),
-    td::Td::new(),
-    td::Td::new(),
-    td::Td::new(),
-    td::Td::new(),
-    td::Td::new(),
-    td::Td::new(),
-    td::Td::new(),
-    td::Td::new(),
-    td::Td::new(),
-    td::Td::new(),
-    td::Td::new(),
-    td::Td::new(),
-    td::Td::new(),
-    td::Td::new(),
-    td::Td::new(),
-]);
+struct TdList<const COUNT: usize>([UnsafeCell<Td>; COUNT]);
+
+impl<const COUNT: usize> TdList<COUNT> {
+    const fn new() -> Self {
+        const TD: UnsafeCell<Td> = UnsafeCell::new(Td::new());
+        Self([TD; COUNT])
+    }
+}
 
 /// A list of queue heads
 ///
 /// One queue head per endpoint, per direction (default).
 #[repr(align(4096))]
-struct QhList([qh::Qh; QH_COUNT]);
-const QH_LIST_INIT: QhList = QhList([
-    qh::Qh::new(),
-    qh::Qh::new(),
-    qh::Qh::new(),
-    qh::Qh::new(),
-    qh::Qh::new(),
-    qh::Qh::new(),
-    qh::Qh::new(),
-    qh::Qh::new(),
-    qh::Qh::new(),
-    qh::Qh::new(),
-    qh::Qh::new(),
-    qh::Qh::new(),
-    qh::Qh::new(),
-    qh::Qh::new(),
-    qh::Qh::new(),
-    qh::Qh::new(),
-]);
+struct QhList<const COUNT: usize>([UnsafeCell<Qh>; COUNT]);
 
-struct State {
-    qhs: QhList,
-    tds: TdList,
-}
-
-const STATE_INIT: State = State {
-    qhs: QH_LIST_INIT,
-    tds: TD_LIST_INIT,
-};
-
-static mut USB1_STATE: State = STATE_INIT;
-static mut USB2_STATE: State = STATE_INIT;
-
-unsafe fn state(usb: &ral::usb::Instance) -> &'static mut State {
-    match &**usb as *const _ {
-        ral::usb::USB1 => &mut USB1_STATE,
-        ral::usb::USB2 => &mut USB2_STATE,
-        _ => unreachable!("ral module ensures that the USB instance is one of these two value"),
+impl<const COUNT: usize> QhList<COUNT> {
+    const fn new() -> Self {
+        const QH: UnsafeCell<Qh> = UnsafeCell::new(Qh::new());
+        Self([QH; COUNT])
     }
 }
 
-/// Returns a pointer to the queue heads collection for this USB instance
+/// The collection of endpoints.
 ///
-/// This is only safe to use when assigning the ENDPTLISTADDR to the USB
-/// instance.
-pub fn assign_endptlistaddr(usb: &ral::usb::Instance) {
-    let ptr = unsafe { state(usb).qhs.0.as_ptr() };
-    ral::write_reg!(ral::usb, usb, ASYNCLISTADDR, ptr as u32);
+/// Maintained inside the EndpointState so that it's sized just right.
+struct EpList<const COUNT: usize>([UnsafeCell<MaybeUninit<Endpoint>>; COUNT]);
+
+impl<const COUNT: usize> EpList<COUNT> {
+    const fn new() -> Self {
+        const EP: UnsafeCell<MaybeUninit<Endpoint>> = UnsafeCell::new(MaybeUninit::uninit());
+        Self([EP; COUNT])
+    }
 }
 
-/// "Steal" the queue heads for this USB state, and return an array of references to queue
-/// heads
+/// The maximum supported number of endpoints.
 ///
-/// # Safety
-///
-/// This should only be called once. You must make sure that the static, mutable references
-/// aren't mutably aliased. Consider taking them from this collection, and assigning them
-/// elsewhere.
-pub unsafe fn steal_qhs(usb: &ral::usb::Instance) -> [Option<&'static mut qh::Qh>; QH_COUNT] {
-    let mut qhs = [
-        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-        None,
-    ];
-    for (dst, src) in qhs.iter_mut().zip(state(usb).qhs.0.iter_mut()) {
-        *dst = Some(src);
-    }
-    qhs
+/// Eight endpoints, two in each direction. Any endpoints allocated
+/// beyond this are wasted.
+pub const MAX_ENDPOINTS: usize = 8 * 2;
+
+/// Produces an index into the EPs, QHs, and TDs collections
+fn index(ep_addr: EndpointAddress) -> usize {
+    (ep_addr.index() * 2) + (UsbDirection::In == ep_addr.direction()) as usize
 }
 
-/// "Steal" the transfer descriptors for this USB state, and return an array of transfer
-/// descriptor references.
+/// Driver state associated with endpoints.
 ///
-/// # Safety
+/// Each USB driver needs an `EndpointState`. Allocate a `static` object
+/// and supply it to your USB constructor. Make sure that states are not
+/// shared across USB instances; otherwise, the driver constructor panics.
 ///
-/// This should only be called once. You must make sure that the static, mutable references
-/// aren't mutably aliased. Consider taking them from this collection, and assigning them
-/// elsewhere.
-pub unsafe fn steal_tds(usb: &ral::usb::Instance) -> [Option<&'static mut td::Td>; QH_COUNT] {
-    let mut tds = [
-        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-        None,
-    ];
-    for (dst, src) in tds.iter_mut().zip(state(usb).tds.0.iter_mut()) {
-        *dst = Some(src);
+/// Use [`max_endpoints()`](EndpointState::max_endpoints) if you're not interested in reducing the
+/// memory used by this allocation. The default object holds enough
+/// state for all supported endpoints.
+///
+/// ```
+/// use imxrt_usbd::EndpointState;
+///
+/// static EP_STATE: EndpointState = EndpointState::max_endpoints();
+/// ```
+///
+/// If you know that you can use fewer endpoints, you can control the
+/// memory utilization with the const generic `COUNT`. You're expected
+/// to provide at least two endpoints -- one in each direction -- for
+/// control endpoints.
+///
+/// Know that endpoints are allocated in pairs; all even endpoints are
+/// OUT, and all odd endpoints are IN. For example, a `COUNT` of 5 will
+/// have 3 out endpoints, and 2 in endpoints. You can never have more
+/// IN that OUT endpoints without overallocating OUT endpoints.
+///
+/// ```
+/// use imxrt_usbd::EndpointState;
+///
+/// static EP_STATE: EndpointState<5> = EndpointState::new();
+/// ```
+///
+/// Any endpoint state allocated beyond [`MAX_ENDPOINTS`] are wasted.
+pub struct EndpointState<const COUNT: usize = MAX_ENDPOINTS> {
+    qh_list: QhList<COUNT>,
+    td_list: TdList<COUNT>,
+    ep_list: EpList<COUNT>,
+    /// Low 16 bits are used for tracking endpoint allocation.
+    /// Bit 31 is set when the allocator is first taken. This
+    /// bit is always dropped during u32 -> u16 conversions.
+    alloc_mask: AtomicU32,
+}
+
+unsafe impl<const COUNT: usize> Sync for EndpointState<COUNT> {}
+
+impl EndpointState<MAX_ENDPOINTS> {
+    /// Allocate space for the maximum number of endpoints.
+    ///
+    /// Use this if you don't want to consider the exact number
+    /// of endpoints that you might need.
+    pub const fn max_endpoints() -> Self {
+        Self::new()
     }
-    tds
+}
+
+impl<const COUNT: usize> EndpointState<COUNT> {
+    /// Allocate state for `COUNT` endpoints.
+    pub const fn new() -> Self {
+        Self {
+            qh_list: QhList::new(),
+            td_list: TdList::new(),
+            ep_list: EpList::new(),
+            alloc_mask: AtomicU32::new(0),
+        }
+    }
+
+    /// Acquire the allocator.
+    ///
+    /// Returns `None` if the allocator was already taken.
+    pub(crate) fn allocator(&self) -> Option<EndpointAllocator> {
+        const ALLOCATOR_TAKEN: u32 = 1 << 31;
+        let alloc_mask = self.alloc_mask.fetch_or(ALLOCATOR_TAKEN, Ordering::SeqCst);
+        (alloc_mask & ALLOCATOR_TAKEN == 0).then(|| EndpointAllocator {
+            qh_list: &self.qh_list.0[..self.qh_list.0.len().min(MAX_ENDPOINTS)],
+            td_list: &self.td_list.0[..self.td_list.0.len().min(MAX_ENDPOINTS)],
+            ep_list: &self.ep_list.0[..self.ep_list.0.len().min(MAX_ENDPOINTS)],
+            alloc_mask: &self.alloc_mask,
+        })
+    }
+}
+
+pub struct EndpointAllocator<'a> {
+    qh_list: &'a [UnsafeCell<Qh>],
+    td_list: &'a [UnsafeCell<Td>],
+    ep_list: &'a [UnsafeCell<MaybeUninit<Endpoint>>],
+    alloc_mask: &'a AtomicU32,
+}
+
+unsafe impl Send for EndpointAllocator<'_> {}
+
+impl EndpointAllocator<'_> {
+    /// Atomically inserts the endpoint bit into the allocation mask, returning `None` if the
+    /// bit was already set.
+    fn try_mask_update(&mut self, mask: u16) -> Option<()> {
+        let mask = mask.into();
+        (mask & self.alloc_mask.fetch_or(mask, Ordering::SeqCst) == 0).then_some(())
+    }
+
+    /// Returns `Some` if the endpoint is allocated.
+    fn check_allocated(&self, index: usize) -> Option<()> {
+        let mask = (index < self.qh_list.len()).then_some(1u16 << index)?;
+        (mask & self.alloc_mask.load(Ordering::SeqCst) as u16 != 0).then_some(())
+    }
+
+    /// Acquire the QH list address.
+    ///
+    /// Used to tell the hardware where the queue heads are located.
+    pub fn qh_list_addr(&self) -> *const () {
+        self.qh_list.as_ptr().cast()
+    }
+
+    /// Returns the total number of endpoints that could be allocated.
+    pub fn capacity(&self) -> usize {
+        self.ep_list.len()
+    }
+
+    /// Acquire the endpoint.
+    ///
+    /// Returns `None` if the endpoint isn't allocated.
+    pub fn endpoint(&self, addr: EndpointAddress) -> Option<&Endpoint> {
+        let index = index(addr);
+        self.check_allocated(index)?;
+
+        // Safety: there's no other mutable access at this call site.
+        // Perceived lifetime is tied to the EndpointAllocator, which has an
+        // immutable receiver.
+
+        let ep = unsafe { &*self.ep_list[index].get() };
+        // Safety: endpoint is allocated. Checked above.
+        Some(unsafe { ep.assume_init_ref() })
+    }
+
+    /// Aquire the mutable endpoint.
+    ///
+    /// Returns `None` if the endpoint isn't allocated.
+    pub fn endpoint_mut(&mut self, addr: EndpointAddress) -> Option<&mut Endpoint> {
+        let index = index(addr);
+        self.check_allocated(index)?;
+
+        // Safety: there's no other immutable or mutable access at this call site.
+        // Perceived lifetime is tied to the EndpointAllocator, which has a
+        // mutable receiver.
+        let ep = unsafe { &mut *self.ep_list[index].get() };
+
+        // Safety: endpoint is allocated. Checked above.
+        Some(unsafe { ep.assume_init_mut() })
+    }
+
+    /// Allocate the endpoint for the specified address.
+    ///
+    /// Returns `None` if any are true:
+    ///
+    /// - The endpoint is already allocated.
+    /// - We cannot allocate an endpoint for the given address.
+    pub fn allocate_endpoint(
+        &mut self,
+        addr: EndpointAddress,
+        buffer: Buffer,
+        kind: EndpointType,
+    ) -> Option<&mut Endpoint> {
+        let index = index(addr);
+        let mask = (index < self.qh_list.len()).then_some(1u16 << index)?;
+
+        // If we pass this call, we're the only caller able to observe mutable
+        // QHs, TDs, and EPs at index.
+        self.try_mask_update(mask)?;
+
+        // Safety: index in range. Atomic update on alloc_mask prevents races for
+        // allocation, and ensures that we only release one &mut reference for each
+        // component.
+        let qh = unsafe { &mut *self.qh_list[index].get() };
+        let td = unsafe { &mut *self.td_list[index].get() };
+        // We cannot access these two components after this call. The endpoint
+        // takes mutable references, so it has exclusive ownership of both.
+        // This module is designed to isolate this access so we can visually
+        // see where we have these &mut accesses.
+
+        // EP is uninitialized.
+        let ep = unsafe { &mut *self.ep_list[index].get() };
+        // Nothing to drop here.
+        ep.write(Endpoint::new(addr, qh, td, buffer, kind));
+        // Safety: EP is initialized.
+        Some(unsafe { ep.assume_init_mut() })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EndpointAddress, EndpointState, EndpointType};
+    use crate::buffer;
+
+    #[test]
+    fn acquire_allocator() {
+        let ep_state = EndpointState::max_endpoints();
+        ep_state.allocator().unwrap();
+        for _ in 0..10 {
+            assert!(ep_state.allocator().is_none());
+        }
+    }
+
+    #[test]
+    fn allocate_endpoint() {
+        let mut buffer = [0; 128];
+        let mut buffer_alloc = unsafe { buffer::Allocator::from_buffer(&mut buffer) };
+        let ep_state = EndpointState::max_endpoints();
+        let mut ep_alloc = ep_state.allocator().unwrap();
+
+        // First endpoint allocation.
+        let addr = EndpointAddress::from(0);
+        assert!(ep_alloc.endpoint(addr).is_none());
+        assert!(ep_alloc.endpoint_mut(addr).is_none());
+
+        let ep = ep_alloc
+            .allocate_endpoint(addr, buffer_alloc.allocate(2).unwrap(), EndpointType::Bulk)
+            .unwrap();
+        assert_eq!(ep.address(), addr);
+
+        assert!(ep_alloc.endpoint(addr).is_some());
+        assert!(ep_alloc.endpoint_mut(addr).is_some());
+
+        // Double-allocate existing endpoint.
+        let ep =
+            ep_alloc.allocate_endpoint(addr, buffer_alloc.allocate(2).unwrap(), EndpointType::Bulk);
+        assert!(ep.is_none());
+
+        assert!(ep_alloc.endpoint(addr).is_some());
+        assert!(ep_alloc.endpoint_mut(addr).is_some());
+
+        // Allocate a new endpoint.
+        let addr = EndpointAddress::from(1 << 7);
+
+        assert!(ep_alloc.endpoint(addr).is_none());
+        assert!(ep_alloc.endpoint_mut(addr).is_none());
+
+        let ep = ep_alloc
+            .allocate_endpoint(addr, buffer_alloc.allocate(2).unwrap(), EndpointType::Bulk)
+            .unwrap();
+        assert_eq!(ep.address(), addr);
+    }
 }


### PR DESCRIPTION
In order to support 11xx MCUs (and, turns out, the special 1010), we can't assume that the USB and USBPHY register blocks are at a fixed location. Instead, we need a way to vary the register block location based on the chip, but (ideally) without bringing in `imxrt-ral`. This PR changes the `Peripherals` trait to achieve that goal. Implementations now return pointers to the register blocks, not USB instance numbers.

Once we drop the USB instance numbers, we can't immediately assign static endpoint state, like endpoint queue heads (QH) and transfer descriptors (TD), to the USB driver. Instead of asking `Peripherals` implementations to also identify their USB instance, I took an approach where the endpoint state is allocated by the user, outside of the library.

After this PR, users are responsible for allocating an `EndpointState` and supplying it to the driver. `EndpointState` maintains QHs, TDs, and `Endpoint` objects, and runtime checks assert that states are not assigned to multiple USB drivers. The benefit is that the user can shrink the total number of supported endpoints, and the associated memory footprint, through a const generic.

The PR also changes the API for supplying endpoint memory. Users now use an `EndpointMemory` to define a byte allocation for the driver. Users no longer need an `unsafe` when supplying the buffer to the driver.

Tested with the `test_class` example. Also tested through `imxrt-log` (imxrt-rs/imxrt-hal#121).