### PR TITLE
Fix left shift overflow when preparing endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 [Unreleased]
 ------------
 
+Fix an overflowing left shift that could occur when enabling and allocating
+endpoints.
+
 [0.2.0] 2022-11-30
 ------------------
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,6 @@ members = [
 
 [workspace.package]
 edition = "2021"
+
+[profile.release]
+overflow-checks = true


### PR DESCRIPTION
The endpoint addresses produced by the driver could result in a left-shift overflow back in the state module (panic in `check_allocated`). See the commit message for more details.

The commit refactors the modules, moving the iterator construction into the endpoint allocator. The allocator ensures that the accessed endpoints are valid and won't cause a panic on access.

The Teensy 4 examples should have demonstrated this panic. And I was able to demonstrate the issue with a debug build just before this commit. I likely only tested release builds when preparing the release, and release builds hide this defect. To prevent this in the future, I'm enabling overflow checks in release builds.

I tested this by building debug builds of the serial example on the Teensy 4, and ensuring that it did not panic. The test_class continues to pass the usb-device test suite.