### PR TITLE
Remove endpoint (re)init due to port change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 [Unreleased]
 ------------
 
+Resolve an issue where endpoints were reset when exiting suspend.
+
 [0.2.1] 2023-03-14
 ------------------
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -145,9 +145,9 @@ impl Driver {
     pub fn set_interrupts(&mut self, interrupts: bool) {
         if interrupts {
             // Keep this in sync with the poll() behaviors
-            ral::modify_reg!(ral::usb, self.usb, USBINTR, UE: 1, URE: 1, PCE: 1);
+            ral::modify_reg!(ral::usb, self.usb, USBINTR, UE: 1, URE: 1);
         } else {
-            ral::modify_reg!(ral::usb, self.usb, USBINTR, UE: 0, URE: 0, PCE: 0);
+            ral::modify_reg!(ral::usb, self.usb, USBINTR, UE: 0, URE: 0);
         }
     }
 
@@ -186,6 +186,8 @@ impl Driver {
             "Took too long to handle bus reset"
         );
         debug!("RESET");
+
+        self.initialize_endpoints();
     }
 
     /// Check if the endpoint is valid
@@ -400,11 +402,6 @@ impl Driver {
         if usbsts & USBSTS::URI::mask != 0 {
             ral::write_reg!(ral::usb, self.usb, USBSTS, URI: 1);
             return PollResult::Reset;
-        }
-
-        if usbsts & USBSTS::PCI::mask != 0 {
-            ral::write_reg!(ral::usb, self.usb, USBSTS, PCI: 1);
-            self.initialize_endpoints();
         }
 
         if usbsts & USBSTS::UI::mask != 0 {


### PR DESCRIPTION
When the USB device exits the suspend state to resume operation, the device observes a port change. Before this commit, this port change would initialize and disable all non-zero endpoints. By resetting endpoints without re-enabling them, the USB device stops functioning.

We should make sure the endpoints are in a known state before operation, and we can handle that when responding to bus resets.

Closes #23.