### PR TITLE
Update to usb-device 0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 [Unreleased]
 ------------
 
+**BREAKING** Update to `usb-device` 0.3. By adopting this release, you're
+required to use `usb-device` 0.3 and its compatible packages.
+
 [0.2.2] 2023-09-15
 ------------------
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 bitflags = "1.2"
 cortex-m = "0.7"
 ral-registers = "0.1"
-usb-device = "0.2"
+usb-device = "0.3"
 
 [dependencies.log]
 optional = true

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -169,11 +169,11 @@ mod test {
 
     #[test]
     fn allocate_entire_buffer() {
-        static mut BUFFER: [u8; 32] = [0; 32];
-        let mut alloc = unsafe { Allocator::new(&mut BUFFER) };
+        let mut buffer: [u8; 32] = [0; 32];
+        let mut alloc = unsafe { Allocator::from_buffer(&mut buffer) };
         let ptr = alloc.allocate(32);
         assert!(ptr.is_some());
-        assert_eq!(ptr.unwrap().ptr, unsafe { BUFFER.as_mut_ptr() });
+        assert_eq!(ptr.unwrap().ptr, buffer.as_mut_ptr());
 
         let ptr = alloc.allocate(1);
         assert!(ptr.is_none());
@@ -181,17 +181,17 @@ mod test {
 
     #[test]
     fn allocate_partial_buffers() {
-        static mut BUFFER: [u8; 32] = [0; 32];
-        let mut alloc = unsafe { Allocator::new(&mut BUFFER) };
+        let mut buffer: [u8; 32] = [0; 32];
+        let mut alloc = unsafe { Allocator::from_buffer(&mut buffer) };
 
         let ptr = alloc.allocate(7);
         assert!(ptr.is_some());
-        assert_eq!(ptr.unwrap().ptr, unsafe { BUFFER.as_mut_ptr().add(32 - 7) });
+        assert_eq!(ptr.unwrap().ptr, unsafe { buffer.as_mut_ptr().add(32 - 7) });
 
         let ptr = alloc.allocate(7);
         assert!(ptr.is_some());
         assert_eq!(ptr.unwrap().ptr, unsafe {
-            BUFFER.as_mut_ptr().add(32 - 14)
+            buffer.as_mut_ptr().add(32 - 14)
         });
 
         let ptr = alloc.allocate(19);

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -181,7 +181,9 @@ impl BusAdapter {
             buffer,
             state,
             speed,
-            Some(cortex_m::interrupt::CriticalSection::new()),
+            // Safety: see the above API docs. Caller knows that we're faking our
+            // Sync capability.
+            Some(unsafe { cortex_m::interrupt::CriticalSection::new() }),
         )
     }
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -65,7 +65,7 @@ pub use super::driver::Speed;
 /// use usb_device::prelude::*;
 /// let bus_allocator = usb_device::bus::UsbBusAllocator::new(bus_adapter);
 /// let mut device = UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x5824, 0x27dd))
-///     .product("imxrt-usbd")
+///     .strings(&[StringDescriptors::default().product("imxrt-usbd")]).unwrap()
 ///     // Other builder methods...
 ///     .build();
 ///

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -105,10 +105,10 @@ impl Endpoint {
             let endptctrl = endpoint_control::register(usb, self.address.index());
             match self.address.direction() {
                 UsbDirection::In => {
-                    ral::modify_reg!(endpoint_control, &endptctrl, ENDPTCTRL, TXE: 0, TXT: EndpointType::Bulk as u32)
+                    ral::modify_reg!(endpoint_control, &endptctrl, ENDPTCTRL, TXE: 0, TXT: into_raw_endpoint_type(EndpointType::Bulk))
                 }
                 UsbDirection::Out => {
-                    ral::modify_reg!(endpoint_control, &endptctrl, ENDPTCTRL, RXE: 0, RXT: EndpointType::Bulk as u32)
+                    ral::modify_reg!(endpoint_control, &endptctrl, ENDPTCTRL, RXE: 0, RXT: into_raw_endpoint_type(EndpointType::Bulk))
                 }
             }
         }
@@ -248,10 +248,10 @@ impl Endpoint {
             let endptctrl = endpoint_control::register(usb, self.address.index());
             match self.address.direction() {
                 UsbDirection::In => {
-                    ral::modify_reg!(endpoint_control, &endptctrl, ENDPTCTRL, TXE: 1, TXR: 1, TXT: self.kind as u32)
+                    ral::modify_reg!(endpoint_control, &endptctrl, ENDPTCTRL, TXE: 1, TXR: 1, TXT: into_raw_endpoint_type(self.kind))
                 }
                 UsbDirection::Out => {
-                    ral::modify_reg!(endpoint_control, &endptctrl, ENDPTCTRL, RXE: 1, RXR: 1, RXT: self.kind as u32)
+                    ral::modify_reg!(endpoint_control, &endptctrl, ENDPTCTRL, RXE: 1, RXR: 1, RXT: into_raw_endpoint_type(self.kind))
                 }
             }
         }
@@ -283,4 +283,14 @@ impl Endpoint {
             }
         }
     }
+}
+
+/// Converts the endpoint type into its ENDPTCTRL endpoint type
+/// enumerations.
+///
+/// See the ENDPTCTRL register documentation in the reference manual.
+fn into_raw_endpoint_type(ep_type: EndpointType) -> u32 {
+    // Bits 0..1 represent the transfer type for the endpoint,
+    // and it's compatible with ENDPTCTRL's enumerated values.
+    (ep_type.to_bm_attributes() & 0b11u8).into()
 }

--- a/src/gpt.rs
+++ b/src/gpt.rs
@@ -43,7 +43,7 @@
 //! let bus_allocator = usb_device::bus::UsbBusAllocator::new(bus_adapter);
 //!
 //! let mut device = UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x5824, 0x27dd))
-//!     .product("imxrt-usbd")
+//!     .strings(&[StringDescriptors::default().product("imxrt-usbd")]).unwrap()
 //!     .build();
 //!
 //! // You can still access the timer through the bus() method on

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 //! [`usb-device`]: https://crates.io/crates/usb-device
 
 #![no_std]
+#![warn(unsafe_op_in_unsafe_fn)]
 
 #[macro_use]
 mod log;


### PR DESCRIPTION
The new upstream package provides additional driver configurations, including USB device revisions. Controlling bcdUSB can help users smooth over device compliance issues.

Our public API is unchanged. However, we're only compatible with usb-device 0.3 and its associated ecosystem of packages.