### PR TITLE
Fix min-versions; add min-version CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,23 @@ jobs:
         command: fmt
         args: --verbose --all -- --check
 
+  cortex-m-compat:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        components: clippy
+        target: thumbv7em-none-eabihf
+        override: true
+        profile: minimal
+    - name: Check cortex-m compatibility
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --manifest-path i-need-min-cm/Cargo.toml
+
   # For each chip, build and lint the main library
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         uses: taiki-e/install-action@cargo-minimal-versions
 
       - name: Check with minimal versions
-        run: cargo minimal-versions check
+        run: cargo minimal-versions check --all-features
 
       - name: Run tests with minimal versions
         run: cargo minimal-versions test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,19 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: rustup component add rustfmt
     - name: Check library formatting
       uses: actions-rs/cargo@v1
       with:
         command: fmt
         args: --verbose --all -- --check
-  
+
   # For each chip, build and lint the main library
   clippy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -42,12 +42,34 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Run unit and documentation tests
       uses: actions-rs/cargo@v1
       with:
         command: test
         args: --verbose
+
+  # Check if dependency versions in Cargo.toml are updated correctly
+  min-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: thumbv7em-none-eabihf
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - name: Install cargo-minimal-versions
+        uses: taiki-e/install-action@cargo-minimal-versions
+
+      - name: Check with minimal versions
+        run: cargo minimal-versions check
+
+      - name: Run tests with minimal versions
+        run: cargo minimal-versions test
 
   # Make sure documentation builds, and doclinks are valid
   doc:
@@ -55,7 +77,7 @@ jobs:
       RUSTDOCFLAGS: -D warnings
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Check documentation and doclinks
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: thumbv7em-none-eabihf
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
@@ -66,10 +69,10 @@ jobs:
         uses: taiki-e/install-action@cargo-minimal-versions
 
       - name: Check with minimal versions
-        run: cargo minimal-versions check --all-features
+        run: cargo +stable minimal-versions check --all-features
 
       - name: Run tests with minimal versions
-        run: cargo minimal-versions test
+        run: cargo +stable minimal-versions test
 
   # Make sure documentation builds, and doclinks are valid
   doc:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ optional = true
 [features]
 "defmt-03" = ["dep:defmt-03", "usb-device/defmt"]
 
+[workspace]
+exclude = ["i-need-min-cm"]
+
 [package.metadata.docs.rs]
 default-target = "thumbv7em-none-eabihf"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ exclude = [
 
 [dependencies]
 bitflags = "2"
-cortex-m = "0.7"
+cortex-m = "0.7.4"
 ral-registers = "0.1"
-usb-device = "0.3"
+usb-device = "0.3.1"
 
 [dependencies.defmt-03]
 package = "defmt"

--- a/i-need-min-cm/Cargo.toml
+++ b/i-need-min-cm/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "i-need-min-cm"
+version = "0.1.0"
+
+[dependencies]
+cortex-m = "=0.7.0"
+imxrt-usbd = { path = ".." }

--- a/i-need-min-cm/src/lib.rs
+++ b/i-need-min-cm/src/lib.rs
@@ -1,0 +1,2 @@
+use cortex_m as _;
+use imxrt_usbd as _;


### PR DESCRIPTION
In an ongoing quest of mine to run a min-versions test for `imxrt-uart-panic`, I stumbled across incorrect minimal versions in this crate.

I also added a CI check that makes sure versions are updated in the future.