### PR TITLE
Set MSRV to 1.74; add CI check for it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,8 @@ jobs:
 
       - name: Check MSRV
         # Enable this to automatically determine what the MSRV should be
-        #run: cargo msrv --output-format json --target=thumbv7em-none-eabihf
-        run: cargo msrv --output-format json --target=thumbv7em-none-eabihf verify
+        #run: cargo msrv --output-format json --target=thumbv7em-none-eabihf --all-features
+        run: cargo msrv --output-format json --target=thumbv7em-none-eabihf --all-features verify
 
   # Make sure documentation builds, and doclinks are valid
   doc:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         command: fmt
         args: --verbose --all -- --check
-  
+
   # For each chip, build and lint the main library
   clippy:
     runs-on: ubuntu-latest
@@ -48,6 +48,29 @@ jobs:
       with:
         command: test
         args: --verbose
+
+  # Check if MSRV (Minimal Supported Rust Version) in Cargo.toml can compile the project
+  msrv:
+    name: Minimum Supported Rust Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-binstall
+
+      - name: Install cargo-msrv
+        run: cargo binstall --version 0.16.0-beta.20 --no-confirm cargo-msrv
+
+      #- uses: Swatinem/rust-cache@v1
+
+      - name: Check MSRV
+        # Enable this to automatically determine what the MSRV should be
+        #run: cargo msrv --output-format json --target=thumbv7em-none-eabihf
+        run: cargo msrv --output-format json --target=thumbv7em-none-eabihf verify
 
   # Make sure documentation builds, and doclinks are valid
   doc:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.0"
 authors = ["Ian McIntyre <ianpmcintyre@gmail.com>"]
 repository = "https://github.com/imxrt-rs/imxrt-usbd"
 edition.workspace = true
+rust-version.workspace = true
 license = "MIT OR Apache-2.0"
 keywords = ["imxrt", "nxp", "embedded", "usb"]
 categories = ["embedded", "no-std"]
@@ -35,6 +36,7 @@ default-target = "thumbv7em-none-eabihf"
 
 [workspace.package]
 edition = "2021"
+rust-version = "1.74"
 
 [profile.release]
 overflow-checks = true


### PR DESCRIPTION
MSRV determined by running:

```none
$ cargo msrv --target=thumbv7em-none-eabihf
  [Meta]   cargo-msrv 0.16.0-beta.20                                                                                                                                                              

Compatibility Check #1: Rust 1.38.0
  [FAIL]   Is incompatible

  ╭────────────────────────────────────────────────────────────────────────╮
  │ error: failed to parse manifest at `D:\Projects\imxrt-usbd\Cargo.toml` │
  │                                                                        │
  │ Caused by:                                                             │
  │   invalid type: map, expected a string for key `package.edition`       │
  │                                                                        │
  ╰────────────────────────────────────────────────────────────────────────╯


Compatibility Check #2: Rust 1.58.1                                                                                                                                                               
  [FAIL]   Is incompatible

  ╭────────────────────────────────────────────────────────────────────────╮
  │ error: failed to parse manifest at `D:\Projects\imxrt-usbd\Cargo.toml` │
  │                                                                        │
  │ Caused by:                                                             │
  │   invalid type: map, expected a string for key `package.edition`       │
  │                                                                        │
  ╰────────────────────────────────────────────────────────────────────────╯


Compatibility Check #3: Rust 1.68.2                                                                                                                                                               
  [FAIL]   Is incompatible

  ╭──────────────────────────────────────────────────────────────────────────╮
  │     Checking imxrt-usbd v0.3.0 (D:\Projects\imxrt-usbd)                  │
  │ error[E0446]: crate-private type `Status` in public interface            │
  │    --> src\td.rs:69:5                                                    │
  │     |                                                                    │
  │ 69  |       pub fn status(&self) -> Status {                             │
  │     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak crate-private type │
  │ ...                                                                      │
  │ 110 | / bitflags::bitflags! {                                            │
  │ 111 | |     pub(crate) struct Status : u32 {                             │
  │ 112 | |         const ACTIVE = TOKEN::STATUS::RW::ACTIVE;                │
  │ 113 | |         const HALTED = TOKEN::STATUS::RW::HALTED;                │
  │ ...   |                                                                  │
  │ 116 | |     }                                                            │
  │ 117 | | }                                                                │
  │     | |_- `Status` declared as crate-private                             │
  │                                                                          │
  │ For more information about this error, try `rustc --explain E0446`.      │
  │ error: could not compile `imxrt-usbd` due to previous error              │
  │                                                                          │
  ╰──────────────────────────────────────────────────────────────────────────╯


Compatibility Check #4: Rust 1.73.0                                                                                                                                                               
  [FAIL]   Is incompatible

  ╭──────────────────────────────────────────────────────────────────────────╮
  │     Checking imxrt-usbd v0.3.0 (D:\Projects\imxrt-usbd)                  │
  │ error[E0446]: crate-private type `Status` in public interface            │
  │    --> src\td.rs:69:5                                                    │
  │     |                                                                    │
  │ 69  |       pub fn status(&self) -> Status {                             │
  │     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak crate-private type │
  │ ...                                                                      │
  │ 110 | / bitflags::bitflags! {                                            │
  │ 111 | |     pub(crate) struct Status : u32 {                             │
  │ 112 | |         const ACTIVE = TOKEN::STATUS::RW::ACTIVE;                │
  │ 113 | |         const HALTED = TOKEN::STATUS::RW::HALTED;                │
  │ ...   |                                                                  │
  │ 116 | |     }                                                            │
  │ 117 | | }                                                                │
  │     | |_- `Status` declared as crate-private                             │
  │                                                                          │
  │ For more information about this error, try `rustc --explain E0446`.      │
  │ error: could not compile `imxrt-usbd` (lib) due to previous error        │
  │                                                                          │
  ╰──────────────────────────────────────────────────────────────────────────╯


Compatibility Check #5: Rust 1.76.0                                                                                                                                                               
  [OK]     Is compatible

Compatibility Check #6: Rust 1.74.1                                                                                                                                                               
  [OK]     Is compatible

Result:
   Considered (min … max):   Rust 0.11.0 … Rust 1.78.0
   Search method:            bisect
   MSRV:                     1.74.1
   Target:                   thumbv7em-none-eabihf
 ```
