### PR TITLE
Add MSRV; add MSRV+minimal-versions check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,19 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: rustup component add rustfmt
     - name: Check library formatting
       uses: actions-rs/cargo@v1
       with:
         command: fmt
         args: --verbose --all -- --check
-  
+
   # For each chip, build and lint the main library
   clippy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -42,12 +42,44 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Run unit and documentation tests
       uses: actions-rs/cargo@v1
       with:
         command: test
         args: --verbose
+
+  # Check if project can be built with MSRV and minimal dependency versions.
+  #
+  # To find out the current MSRV, remove the `rust-version` entry from `Cargo.toml` and run:
+  # cargo minimal-versions msrv --target=thumbv7em-none-eabihf --all-features
+  msrv-and-min-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          tool: cargo-hack, cargo-minimal-versions, cargo-binstall
+
+      - name: Install cargo-msrv
+        run: cargo binstall --version 0.16.0-beta.22 --no-confirm cargo-msrv
+
+      - name: Determine MSRV
+        run: echo "MSRV=$(cargo msrv show --output-format=minimal)" >> $GITHUB_ENV
+
+      - name: Show MSRV
+        run: echo $MSRV
+
+      - name: Install MSRV Rust version
+        run: rustup toolchain install $MSRV --target thumbv7em-none-eabihf
+
+      - name: Check with minimal versions
+        run: cargo +${MSRV} minimal-versions check --target thumbv7em-none-eabihf --all-features
+
+      - name: Run tests with minimal versions
+        run: cargo +${MSRV} minimal-versions test
 
   # Make sure documentation builds, and doclinks are valid
   doc:
@@ -55,7 +87,7 @@ jobs:
       RUSTDOCFLAGS: -D warnings
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Check documentation and doclinks
       uses: actions-rs/cargo@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.0"
 authors = ["Ian McIntyre <ianpmcintyre@gmail.com>"]
 repository = "https://github.com/imxrt-rs/imxrt-usbd"
 edition.workspace = true
+rust-version.workspace = true
 license = "MIT OR Apache-2.0"
 keywords = ["imxrt", "nxp", "embedded", "usb"]
 categories = ["embedded", "no-std"]
@@ -22,6 +23,10 @@ cortex-m = "0.7"
 ral-registers = "0.1"
 usb-device = "0.3"
 
+# Not an actual dependency, but required for min-versions check
+# TODO: Check again at a later time and remove if no longer necessary
+bare-metal = ">= 0.2.4"
+
 [dependencies.defmt-03]
 package = "defmt"
 version = "0.3"
@@ -30,11 +35,15 @@ optional = true
 [features]
 "defmt-03" = ["dep:defmt-03", "usb-device/defmt"]
 
+[dev-dependencies]
+usb-device = "0.3.1"
+
 [package.metadata.docs.rs]
 default-target = "thumbv7em-none-eabihf"
 
 [workspace.package]
 edition = "2021"
+rust-version = "1.74"
 
 [profile.release]
 overflow-checks = true


### PR DESCRIPTION
This is an alternative to #26 and #27.

It combines the MSRV and minimal-versions check. This has several advantages:

- No external dependencies can break the MSRV test through an update.
- Building with the oldest compatible dependency versions has the potential to find the actual minimal Rust version this crate can be built with.
- Even if an update of a dependency breaks this crate for the MSRV (through an MSRV update of itself, for example), we can guarantee to the user that he can still build this crate by reverting to the minimal dependency versions.
