### PR TITLE
Fix defmt feature activation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
     - uses: actions/checkout@v6
     - run: rustup toolchain install stable --no-self-update --profile minimal --component clippy --target thumbv7em-none-eabihf
     - name: Lint the library (all features)
+      env:
+        DEFMT_LOG: trace
       run: cargo clippy --verbose --all-features --target thumbv7em-none-eabihf --features=imxrt-ral/imxrt1011 -- -D warnings
     - name: Lint the library (no default features)
       run: cargo clippy --verbose --target thumbv7em-none-eabihf --features=imxrt-ral/imxrt1011 -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 [Unreleased]
 ------------
 
+Fix the `defmt` feature. Activate the `defmt` feature in usb-device, since this
+package may try to log usb-device items.
+
 [0.4.0] 2026-04-12
 ------------------
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ usb-device = "0.3"
 version = "1.0"
 optional = true
 
+[features]
+defmt = ["dep:defmt", "usb-device/defmt"]
+
 [dev-dependencies]
 imxrt-ral = { version = "0.6", features = ["imxrt1011"] }
 


### PR DESCRIPTION
The latest defmt release will now type check even if a given log level isn't enabled. This revealed a build error. It would have also been revealed if the warn! log level was active in older defmt versions.