### PR TITLE
Don't re-prime a disabled OUT endpoint on unstall

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -317,8 +317,16 @@ impl Driver {
         let ep = self.ep_allocator.endpoint_mut(addr).unwrap();
         ep.set_stalled(&self.usb, stall);
 
-        // Re-prime any OUT endpoints if we're unstalling
-        if !stall && addr.direction() == UsbDirection::Out && !ep.is_primed(&self.usb) {
+        // Re-prime any OUT endpoints if we're unstalling. Only prime an *enabled*
+        // endpoint: priming a disabled OUT endpoint (e.g. a class clearing stalls
+        // in its reset() before SET_CONFIGURATION enables endpoints) leaves a stale
+        // transfer descriptor that the controller never completes once the endpoint
+        // is later enabled.
+        if !stall
+            && addr.direction() == UsbDirection::Out
+            && ep.is_enabled(&self.usb)
+            && !ep.is_primed(&self.usb)
+        {
             let max_packet_len = ep.max_packet_len();
             ep.schedule_transfer(&self.usb, max_packet_len);
         }


### PR DESCRIPTION
ep_stall() re-primes any OUT endpoint when it is unstalled, even if the
endpoint has not been enabled yet by SET_CONFIGURATION. A class that unstalls
its bulk endpoints in its reset() handler hits this, because UsbClass::reset
runs on every USB bus reset, before the device is configured. The endpoint is
primed while still disabled, and the resulting transfer descriptor is never
completed by the controller once the endpoint is later enabled. The OUT
endpoint then silently stops receiving: the host submits the transfer but it
never completes.

In practice this breaks any SCSI/MSC device built on usbd-storage, whose
BulkOnly::reset() calls out_ep.unstall(). The device enumerates but never
receives the first CBW, so the host loops (detect, time out, bus reset) and no
block device ever appears.

Fix: only re-prime on unstall if the endpoint is enabled. A disabled endpoint
is primed correctly by prime_endpoints() at configuration time.

Verified on an NXP MIMXRT1064-EVK. Before: a usbd-storage MSC device never gets
a /dev/sd node (usbmon shows the INQUIRY CBW submitted on bulk-OUT with no
completion). After: it enumerates and a dd write/read-back round-trip passes
byte for byte, at LBA 0 and at a non-zero LBA. A composite CDC-ACM + MSC device
also works. CDC alone always worked (its reset() does not touch endpoints),
which is what isolated the problem to the OUT-endpoint reprime path.